### PR TITLE
feat(ST-167): add e2e test for auth/signup api

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: yarn db:migration:fresh:ci
 
       - name: Run E2E tests
-        # run: yarn test:e2e
+        run: yarn test:e2e
 
       - name: Run Unit tests
-        # run: yarn test
+        run: yarn test

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@nestjs/testing": "^10.3.1",
     "@types/express": "^4.17.21",
     "@types/jest": "29.5.12",
+    "@types/multer": "^1.4.12",
     "@types/node": "^20.14.2",
     "@types/passport-jwt": "^4.0.1",
     "@types/passport-local": "^1.0.38",

--- a/test/auth/auth.e2e-spec.ts
+++ b/test/auth/auth.e2e-spec.ts
@@ -45,19 +45,23 @@ describe("AuthController (e2e)", () => {
   });
 
   describe("POST /auth/signup", () => {
-    it("registers student and returns CREATED(201) with auth token", () => {
+    it("registers student and returns CREATED(201) with auth token", async () => {
       const studentInfo = getStudentInfo();
 
-      request(httpServer)
+      await request(httpServer)
         .post("/auth/signup")
         .send(studentInfo)
         .expect(HttpStatus.CREATED)
         .expect(({ body }) => {
           expect(body.data).toHaveProperty("accessToken");
           expect(body.data).toHaveProperty("user");
-          expect(body.data.user.firstName).toEqual(studentInfo.firstName);
-          expect(body.data.user.claim).toEqual(studentInfo.role);
-          expect(body.data.user.email).toEqual(studentInfo.email);
+          expect(body.data.user).toEqual(
+            expect.objectContaining({
+              firstName: studentInfo.firstName,
+              claim: studentInfo.role,
+              email: studentInfo.email,
+            }),
+          );
         });
     });
 
@@ -65,16 +69,20 @@ describe("AuthController (e2e)", () => {
       await createUniqueCode(dbService);
       const { teacherWithMockValues } = getTeacherInfo();
 
-      request(httpServer)
+      await request(httpServer)
         .post("/auth/signup")
         .send(teacherWithMockValues)
         .expect(HttpStatus.CREATED)
         .expect(({ body }) => {
           expect(body.data).toHaveProperty("accessToken");
           expect(body.data).toHaveProperty("user");
-          expect(body.data.user.firstName).toEqual(teacherWithMockValues.firstName);
-          expect(body.data.user.claim).toEqual(teacherWithMockValues.role);
-          expect(body.data.user.email).toEqual(teacherWithMockValues.email);
+          expect(body.data.user).toEqual(
+            expect.objectContaining({
+              firstName: teacherWithMockValues.firstName,
+              claim: teacherWithMockValues.role,
+              email: teacherWithMockValues.email,
+            }),
+          );
         });
     });
 
@@ -82,15 +90,15 @@ describe("AuthController (e2e)", () => {
       await createUniqueCode(dbService);
       const { teacherWithRandomEmail } = getTeacherInfo();
 
-      request(httpServer)
+      await request(httpServer)
         .post("/auth/signup")
         .send(teacherWithRandomEmail)
         .expect(HttpStatus.UNAUTHORIZED);
     });
 
-    it("should return BAD_REQUEST(400) without user info", () => {
+    it("should return BAD_REQUEST(400) without user info", async () => {
       const userInfo = getValuesWithoutUserInfo();
-      request(httpServer).post("/auth/signup").send(userInfo).expect(HttpStatus.BAD_REQUEST);
+      await request(httpServer).post("/auth/signup").send(userInfo).expect(HttpStatus.BAD_REQUEST);
     });
   });
 });

--- a/test/auth/auth.e2e-spec.ts
+++ b/test/auth/auth.e2e-spec.ts
@@ -1,0 +1,96 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+
+import { EntityManager, IDatabaseDriver, Connection, MikroORM } from "@mikro-orm/core";
+
+import request from "supertest";
+
+import { bootstrapTestServer } from "../utils/bootstrap";
+import { truncateTables } from "../utils/db";
+import {
+  createUniqueCode,
+  getStudentInfo,
+  getTeacherInfo,
+  getValuesWithoutUserInfo,
+} from "../utils/helpers/auth.helpers";
+import { THttpServer } from "../utils/types";
+
+describe("AuthController (e2e)", () => {
+  let app: INestApplication;
+  let dbService: EntityManager<IDatabaseDriver<Connection>>;
+  let httpServer: THttpServer;
+  let orm: MikroORM<IDatabaseDriver<Connection>>;
+
+  beforeAll(async () => {
+    const { appInstance, dbServiceInstance, httpServerInstance, ormInstance } =
+      await bootstrapTestServer();
+    app = appInstance;
+    dbService = dbServiceInstance;
+    httpServer = httpServerInstance;
+    orm = ormInstance;
+  });
+
+  afterAll(async () => {
+    await truncateTables(dbService);
+    await orm.close();
+    await httpServer.close();
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await truncateTables(dbService);
+  });
+
+  afterEach(() => {
+    dbService.clear();
+  });
+
+  describe("POST /auth/signup", () => {
+    it("registers student and returns CREATED(201) with auth token", () => {
+      const studentInfo = getStudentInfo();
+
+      request(httpServer)
+        .post("/auth/signup")
+        .send(studentInfo)
+        .expect(HttpStatus.CREATED)
+        .expect(({ body }) => {
+          expect(body.data).toHaveProperty("accessToken");
+          expect(body.data).toHaveProperty("user");
+          expect(body.data.user.firstName).toEqual(studentInfo.firstName);
+          expect(body.data.user.claim).toEqual(studentInfo.role);
+          expect(body.data.user.email).toEqual(studentInfo.email);
+        });
+    });
+
+    it("registers teacher and returns CREATED(201) with auth token", async () => {
+      await createUniqueCode(dbService);
+      const { teacherWithMockValues } = getTeacherInfo();
+
+      request(httpServer)
+        .post("/auth/signup")
+        .send(teacherWithMockValues)
+        .expect(HttpStatus.CREATED)
+        .expect(({ body }) => {
+          expect(body.data).toHaveProperty("accessToken");
+          expect(body.data).toHaveProperty("user");
+          expect(body.data.user.firstName).toEqual(teacherWithMockValues.firstName);
+          expect(body.data.user.claim).toEqual(teacherWithMockValues.role);
+          expect(body.data.user.email).toEqual(teacherWithMockValues.email);
+        });
+    });
+
+    it("should return Unauthorized(401) as the email doesn't registerd by admin", async () => {
+      await createUniqueCode(dbService);
+      const { teacherWithRandomEmail } = getTeacherInfo();
+
+      request(httpServer)
+        .post("/auth/signup")
+        .send(teacherWithRandomEmail)
+        .expect(HttpStatus.UNAUTHORIZED);
+    });
+
+    it("should return BAD_REQUEST(400) without user info", () => {
+      const userInfo = getValuesWithoutUserInfo();
+      request(httpServer).post("/auth/signup").send(userInfo).expect(HttpStatus.BAD_REQUEST);
+    });
+  });
+});

--- a/test/auth/auth.e2e-spec.ts
+++ b/test/auth/auth.e2e-spec.ts
@@ -2,17 +2,21 @@ import { HttpStatus, INestApplication } from "@nestjs/common";
 
 import { EntityManager, IDatabaseDriver, Connection, MikroORM } from "@mikro-orm/core";
 
+import { faker } from "@faker-js/faker";
 import request from "supertest";
+
+import { EStudentEducationLevel } from "@/common/enums/educationLevel.enum";
+import { EUserGender } from "@/common/enums/gender.enum";
+import { EHighestEducationLevel } from "@/common/enums/highestEducationLevel.enum";
+import { EMedium } from "@/common/enums/medium.enum";
+import { EUserRole } from "@/common/enums/roles.enum";
 
 import { bootstrapTestServer } from "../utils/bootstrap";
 import { truncateTables } from "../utils/db";
-import {
-  createUniqueCode,
-  getStudentInfo,
-  getTeacherInfo,
-  getValuesWithoutUserInfo,
-} from "../utils/helpers/auth.helpers";
+import { createUniqueCodeInDb, getValuesWithoutUserInfo } from "../utils/helpers/auth.helpers";
 import { THttpServer } from "../utils/types";
+import { MOCK_TEACHER_EMAIL, MOCK_TEACHER_UNIQUE_CODE } from "./auth.mock";
+
 
 describe("AuthController (e2e)", () => {
   let app: INestApplication;
@@ -45,9 +49,109 @@ describe("AuthController (e2e)", () => {
   });
 
   describe("POST /auth/signup", () => {
-    it("registers student and returns CREATED(201) with auth token", async () => {
-      const studentInfo = getStudentInfo();
+    type TStudentInput = {
+      address: string;
+      phoneNumber: string;
+      educationLevel: EStudentEducationLevel;
+      medium: EMedium;
+      class: string;
+    };
 
+    type TTeacherInput = {
+      code: string;
+      majorSubject: string;
+      highestEducationLevel: EHighestEducationLevel;
+      subjectsToTeach: string[];
+    };
+
+    type TUser = {
+      firstName: string;
+      lastName: string;
+      gender: EUserGender;
+      email: string;
+      password: string;
+      role: EUserRole;
+      teacherInput?: TTeacherInput;
+      studentInput?: TStudentInput;
+    };
+
+    let teacherWithMockValues: TUser;
+    let teacherWithRandomEmail: TUser;
+    let studentInfo: TUser;
+
+    beforeAll(() => {
+      teacherWithMockValues = {
+        firstName: faker.person.firstName(),
+        lastName: faker.person.lastName(),
+        gender: EUserGender.MALE,
+        email: MOCK_TEACHER_EMAIL,
+        password: faker.internet.password(),
+        role: EUserRole.TEACHER,
+        teacherInput: {
+          code: MOCK_TEACHER_UNIQUE_CODE,
+          majorSubject: faker.helpers.arrayElement([
+            "Physics",
+            "Chemistry",
+            "Math",
+            "Geography",
+            "Communication",
+          ]),
+          highestEducationLevel: faker.helpers.enumValue(EHighestEducationLevel),
+          subjectsToTeach: faker.helpers.arrayElements([
+            "Physics",
+            "Chemistry",
+            "Math",
+            "Geography",
+            "Communication",
+          ]),
+        },
+      };
+
+      teacherWithRandomEmail = {
+        firstName: faker.person.firstName(),
+        lastName: faker.person.lastName(),
+        gender: EUserGender.MALE,
+        email: faker.internet.email(),
+        password: faker.internet.password(),
+        role: EUserRole.TEACHER,
+        teacherInput: {
+          code: MOCK_TEACHER_UNIQUE_CODE,
+          majorSubject: faker.helpers.arrayElement([
+            "Physics",
+            "Chemistry",
+            "Math",
+            "Geography",
+            "Communication",
+          ]),
+          highestEducationLevel: faker.helpers.enumValue(EHighestEducationLevel),
+          subjectsToTeach: faker.helpers.arrayElements([
+            "Physics",
+            "Chemistry",
+            "Math",
+            "Geography",
+            "Communication",
+          ]),
+        },
+      };
+
+      studentInfo = {
+        firstName: faker.person.firstName(),
+        lastName: faker.person.lastName(),
+        gender: EUserGender.MALE,
+        email: faker.internet.email(),
+        password: faker.internet.password(),
+        role: EUserRole.STUDENT,
+        studentInput: {
+          address: faker.location.streetAddress(),
+          phoneNumber: faker.phone.number(),
+          educationLevel: EStudentEducationLevel.SCHOOL,
+          medium: EMedium.BANGLA,
+          class: "Class 1",
+        },
+      };
+    });
+
+    it("registers student and returns CREATED(201) with auth token", async () => {
       await request(httpServer)
         .post("/auth/signup")
         .send(studentInfo)
@@ -66,8 +170,7 @@ describe("AuthController (e2e)", () => {
     });
 
     it("registers teacher and returns CREATED(201) with auth token", async () => {
-      await createUniqueCode(dbService);
-      const { teacherWithMockValues } = getTeacherInfo();
+      await createUniqueCodeInDb(dbService);
 
       await request(httpServer)
         .post("/auth/signup")
@@ -87,8 +190,7 @@ describe("AuthController (e2e)", () => {
     });
 
     it("should return Unauthorized(401) as the email doesn't registerd by admin", async () => {
-      await createUniqueCode(dbService);
-      const { teacherWithRandomEmail } = getTeacherInfo();
+      await createUniqueCodeInDb(dbService);
 
       await request(httpServer)
         .post("/auth/signup")

--- a/test/auth/auth.mock.ts
+++ b/test/auth/auth.mock.ts
@@ -1,0 +1,2 @@
+export const MOCK_TEACHER_EMAIL = "teacher@user.com";
+export const MOCK_TEACHER_UNIQUE_CODE = "1e3fa3";

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,0 +1,13 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "maxWorkers": 1,
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^@/(.*)$": "<rootDir>/../src/$1"
+  }
+}

--- a/test/utils/bootstrap.ts
+++ b/test/utils/bootstrap.ts
@@ -1,0 +1,36 @@
+import { ValidationPipe } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+
+import { MikroORM } from "@mikro-orm/postgresql";
+
+import { mockDeep } from "jest-mock-extended";
+
+import { AppModule } from "@/app.module";
+import { S3Service } from "@/common/aws/s3-service/s3-service";
+import ormConfig from "@/db/db.config";
+import { FileUploadsService } from "@/file-uploads/file-uploads.service";
+
+export const bootstrapTestServer = async () => {
+  const moduleFixture: TestingModule = await Test.createTestingModule({
+    imports: [AppModule],
+  })
+    .overrideProvider(S3Service)
+    .useValue(mockDeep<S3Service>({ funcPropSupport: true }))
+    .overrideProvider(FileUploadsService)
+    .useValue(mockDeep<FileUploadsService>({ funcPropSupport: true }))
+    .compile();
+
+  const app = moduleFixture.createNestApplication();
+  app.useGlobalPipes(new ValidationPipe({ transform: true }));
+  const httpServer = app.getHttpServer();
+  const orm = await MikroORM.init(ormConfig);
+  const entityManager = orm.em.fork();
+  await app.init();
+
+  return {
+    appInstance: app,
+    httpServerInstance: httpServer,
+    dbServiceInstance: entityManager,
+    ormInstance: orm,
+  };
+};

--- a/test/utils/db.ts
+++ b/test/utils/db.ts
@@ -1,0 +1,17 @@
+import { EntityManager, IDatabaseDriver, Connection } from "@mikro-orm/core";
+
+export const truncateTables = async (
+  dbService: EntityManager<IDatabaseDriver<Connection>>,
+): Promise<void> => {
+  const dbConnection = dbService.getConnection();
+
+  const tableNames: Array<{ table_name: string }> = await dbConnection.execute(
+    `SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE' AND table_name != 'mikro_orm_migrations';`,
+  );
+
+  for (const tableNameObj of tableNames) {
+    await dbConnection.execute(
+      `TRUNCATE TABLE "${tableNameObj.table_name}" RESTART IDENTITY CASCADE;`,
+    );
+  }
+};

--- a/test/utils/helpers/auth.helpers.ts
+++ b/test/utils/helpers/auth.helpers.ts
@@ -3,91 +3,10 @@ import { EntityManager } from "@mikro-orm/core";
 import { faker } from "@faker-js/faker";
 
 import { UniqueCode } from "@/common/entities/unique-code.entity";
-import { EStudentEducationLevel } from "@/common/enums/educationLevel.enum";
 import { EUserGender } from "@/common/enums/gender.enum";
-import { EHighestEducationLevel } from "@/common/enums/highestEducationLevel.enum";
-import { EMedium } from "@/common/enums/medium.enum";
 import { EUserRole } from "@/common/enums/roles.enum";
 
 import { MOCK_TEACHER_EMAIL, MOCK_TEACHER_UNIQUE_CODE } from "../../auth/auth.mock";
-
-export const getStudentInfo = () => {
-  const studentInfo = {
-    firstName: faker.person.firstName(),
-    lastName: faker.person.lastName(),
-    gender: EUserGender.MALE,
-    email: faker.internet.email(),
-    password: faker.internet.password(),
-    role: EUserRole.STUDENT,
-    studentInput: {
-      address: faker.location.streetAddress(),
-      phoneNumber: faker.phone.number(),
-      educationLevel: EStudentEducationLevel.SCHOOL,
-      medium: EMedium.BANGLA,
-      class: "Class 1",
-    },
-  };
-
-  return studentInfo;
-};
-
-export const getTeacherInfo = () => {
-  const teacherWithMockValues = {
-    firstName: faker.person.firstName(),
-    lastName: faker.person.lastName(),
-    gender: EUserGender.MALE,
-    email: MOCK_TEACHER_EMAIL,
-    password: faker.internet.password(),
-    role: EUserRole.TEACHER,
-    teacherInput: {
-      code: MOCK_TEACHER_UNIQUE_CODE,
-      majorSubject: faker.helpers.arrayElement([
-        "Physics",
-        "Chemistry",
-        "Math",
-        "Geography",
-        "Communication",
-      ]),
-      highestEducationLevel: faker.helpers.enumValue(EHighestEducationLevel),
-      subjectsToTeach: faker.helpers.arrayElements([
-        "Physics",
-        "Chemistry",
-        "Math",
-        "Geography",
-        "Communication",
-      ]),
-    },
-  };
-
-  const teacherWithRandomEmail = {
-    firstName: faker.person.firstName(),
-    lastName: faker.person.lastName(),
-    gender: EUserGender.MALE,
-    email: faker.internet.email(),
-    password: faker.internet.password(),
-    role: EUserRole.TEACHER,
-    teacherInput: {
-      code: MOCK_TEACHER_UNIQUE_CODE,
-      majorSubject: faker.helpers.arrayElement([
-        "Physics",
-        "Chemistry",
-        "Math",
-        "Geography",
-        "Communication",
-      ]),
-      highestEducationLevel: faker.helpers.enumValue(EHighestEducationLevel),
-      subjectsToTeach: faker.helpers.arrayElements([
-        "Physics",
-        "Chemistry",
-        "Math",
-        "Geography",
-        "Communication",
-      ]),
-    },
-  };
-
-  return { teacherWithMockValues, teacherWithRandomEmail };
-};
 
 export const getValuesWithoutUserInfo = () => ({
   firstName: faker.person.firstName(),
@@ -98,7 +17,7 @@ export const getValuesWithoutUserInfo = () => ({
   role: EUserRole.STUDENT,
 });
 
-export const createUniqueCode = async (em: EntityManager) => {
+export const createUniqueCodeInDb = async (em: EntityManager) => {
   const uniqueCode = em.create(UniqueCode, {
     email: MOCK_TEACHER_EMAIL,
     code: MOCK_TEACHER_UNIQUE_CODE,

--- a/test/utils/helpers/auth.helpers.ts
+++ b/test/utils/helpers/auth.helpers.ts
@@ -38,7 +38,7 @@ export const getTeacherInfo = () => {
     gender: EUserGender.MALE,
     email: MOCK_TEACHER_EMAIL,
     password: faker.internet.password(),
-    role: EUserRole.STUDENT,
+    role: EUserRole.TEACHER,
     teacherInput: {
       code: MOCK_TEACHER_UNIQUE_CODE,
       majorSubject: faker.helpers.arrayElement([
@@ -65,7 +65,7 @@ export const getTeacherInfo = () => {
     gender: EUserGender.MALE,
     email: faker.internet.email(),
     password: faker.internet.password(),
-    role: EUserRole.STUDENT,
+    role: EUserRole.TEACHER,
     teacherInput: {
       code: MOCK_TEACHER_UNIQUE_CODE,
       majorSubject: faker.helpers.arrayElement([

--- a/test/utils/helpers/auth.helpers.ts
+++ b/test/utils/helpers/auth.helpers.ts
@@ -1,0 +1,109 @@
+import { EntityManager } from "@mikro-orm/core";
+
+import { faker } from "@faker-js/faker";
+
+import { UniqueCode } from "@/common/entities/unique-code.entity";
+import { EStudentEducationLevel } from "@/common/enums/educationLevel.enum";
+import { EUserGender } from "@/common/enums/gender.enum";
+import { EHighestEducationLevel } from "@/common/enums/highestEducationLevel.enum";
+import { EMedium } from "@/common/enums/medium.enum";
+import { EUserRole } from "@/common/enums/roles.enum";
+
+import { MOCK_TEACHER_EMAIL, MOCK_TEACHER_UNIQUE_CODE } from "../../auth/auth.mock";
+
+export const getStudentInfo = () => {
+  const studentInfo = {
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    gender: EUserGender.MALE,
+    email: faker.internet.email(),
+    password: faker.internet.password(),
+    role: EUserRole.STUDENT,
+    studentInput: {
+      address: faker.location.streetAddress(),
+      phoneNumber: faker.phone.number(),
+      educationLevel: EStudentEducationLevel.SCHOOL,
+      medium: EMedium.BANGLA,
+      class: "Class 1",
+    },
+  };
+
+  return studentInfo;
+};
+
+export const getTeacherInfo = () => {
+  const teacherWithMockValues = {
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    gender: EUserGender.MALE,
+    email: MOCK_TEACHER_EMAIL,
+    password: faker.internet.password(),
+    role: EUserRole.STUDENT,
+    teacherInput: {
+      code: MOCK_TEACHER_UNIQUE_CODE,
+      majorSubject: faker.helpers.arrayElement([
+        "Physics",
+        "Chemistry",
+        "Math",
+        "Geography",
+        "Communication",
+      ]),
+      highestEducationLevel: faker.helpers.enumValue(EHighestEducationLevel),
+      subjectsToTeach: faker.helpers.arrayElements([
+        "Physics",
+        "Chemistry",
+        "Math",
+        "Geography",
+        "Communication",
+      ]),
+    },
+  };
+
+  const teacherWithRandomEmail = {
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    gender: EUserGender.MALE,
+    email: faker.internet.email(),
+    password: faker.internet.password(),
+    role: EUserRole.STUDENT,
+    teacherInput: {
+      code: MOCK_TEACHER_UNIQUE_CODE,
+      majorSubject: faker.helpers.arrayElement([
+        "Physics",
+        "Chemistry",
+        "Math",
+        "Geography",
+        "Communication",
+      ]),
+      highestEducationLevel: faker.helpers.enumValue(EHighestEducationLevel),
+      subjectsToTeach: faker.helpers.arrayElements([
+        "Physics",
+        "Chemistry",
+        "Math",
+        "Geography",
+        "Communication",
+      ]),
+    },
+  };
+
+  return { teacherWithMockValues, teacherWithRandomEmail };
+};
+
+export const getValuesWithoutUserInfo = () => ({
+  firstName: faker.person.firstName(),
+  lastName: faker.person.lastName(),
+  gender: EUserGender.MALE,
+  email: faker.internet.email(),
+  password: faker.internet.password(),
+  role: EUserRole.STUDENT,
+});
+
+export const createUniqueCode = async (em: EntityManager) => {
+  const uniqueCode = em.create(UniqueCode, {
+    email: MOCK_TEACHER_EMAIL,
+    code: MOCK_TEACHER_UNIQUE_CODE,
+    resetCounter: 3,
+  });
+
+  await em.persistAndFlush(uniqueCode);
+};

--- a/test/utils/types.ts
+++ b/test/utils/types.ts
@@ -1,0 +1,3 @@
+import type { bootstrapTestServer } from "./bootstrap";
+
+export type THttpServer = Awaited<ReturnType<typeof bootstrapTestServer>>["httpServerInstance"];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3549,6 +3549,13 @@
   dependencies:
     "@types/mjml-core" "*"
 
+"@types/multer@^1.4.12":
+  version "1.4.12"
+  resolved "https://registry.yarnpkg.com/@types/multer/-/multer-1.4.12.tgz#da67bd0c809f3a63fe097c458c0d4af1fea50ab7"
+  integrity sha512-pQ2hoqvXiJt2FP9WQVLPRO+AmiIm/ZYkavPlIQnx282u4ZrVdztx0pkh3jjpQt0Kz+YI0YhSG264y08UJKoUQg==
+  dependencies:
+    "@types/express" "*"
+
 "@types/mysql@2.15.19":
   version "2.15.19"
   resolved "https://registry.yarnpkg.com/@types/mysql/-/mysql-2.15.19.tgz#d158927bb7c1a78f77e56de861a3b15cae0e7aed"


### PR DESCRIPTION
## Description of Change

- Added jest configuration
- Added some necessary utils
- Added auth helpers
- Added e2e spect test for POST `auth/signup` API

## Associated Ticket Link(s)

- https://trello.com/c/9e778sT6

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings: N/A
