### PR TITLE
feat(ST-161): add e2e test for get users/me api

### DIFF
--- a/test/users/users.e2e-spec.ts
+++ b/test/users/users.e2e-spec.ts
@@ -1,0 +1,75 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+
+import type { EntityManager, IDatabaseDriver, Connection, MikroORM } from "@mikro-orm/core";
+
+import { faker } from "@faker-js/faker";
+import request from "supertest";
+
+import { User } from "@/common/entities/users.entity";
+
+import { bootstrapTestServer } from "../utils/bootstrap";
+import { truncateTables } from "../utils/db";
+import { getAccessToken } from "../utils/helpers/access-token.helpers";
+import { createUserInDb } from "../utils/helpers/users.helpers";
+import { THttpServer } from "../utils/types";
+
+describe("UsersController (e2e)", () => {
+  let app: INestApplication;
+  let dbService: EntityManager<IDatabaseDriver<Connection>>;
+  let httpServer: THttpServer;
+  let orm: MikroORM<IDatabaseDriver<Connection>>;
+
+  beforeAll(async () => {
+    const { appInstance, dbServiceInstance, httpServerInstance, ormInstance } =
+      await bootstrapTestServer();
+    app = appInstance;
+    dbService = dbServiceInstance;
+    httpServer = httpServerInstance;
+    orm = ormInstance;
+  });
+
+  afterAll(async () => {
+    await truncateTables(dbService);
+    await orm.close();
+    await httpServer.close();
+    await app.close();
+  });
+
+  afterEach(() => {
+    dbService.clear();
+  });
+
+  describe("GET /users/me", () => {
+    const testUserEmail = faker.internet.email();
+    const testUserPassword = faker.internet.password();
+
+    let token: string;
+    let user: User;
+
+    beforeAll(async () => {
+      user = await createUserInDb(dbService, {
+        email: testUserEmail,
+        password: testUserPassword,
+      });
+
+      token = await getAccessToken(httpServer, testUserEmail, testUserPassword);
+    });
+
+    it("returns OK(200) with user data", () =>
+      request(httpServer)
+        .get("/users/me")
+        .set("Authorization", `Bearer ${token}`)
+        .expect(HttpStatus.OK)
+        .expect((response) => {
+          expect(response.body.data).toEqual({
+            id: expect.any(Number),
+            email: testUserEmail,
+            claim: user.role,
+            firstName: user.firstName,
+          });
+        }));
+
+    it("returns UNAUTHORIZED(401) if user is not authenticated", () =>
+      request(httpServer).get("/users/me").expect(HttpStatus.UNAUTHORIZED));
+  });
+});

--- a/test/utils/helpers/access-token.helpers.ts
+++ b/test/utils/helpers/access-token.helpers.ts
@@ -1,0 +1,19 @@
+import { HttpStatus } from "@nestjs/common";
+
+import request from "supertest";
+
+import { MOCK_AUTH_EMAIL, MOCK_AUTH_PASS } from "../../auth/auth.mock";
+import { bootstrapTestServer } from "../bootstrap";
+
+export async function getAccessToken(
+  httpServer: Awaited<ReturnType<typeof bootstrapTestServer>>["httpServerInstance"],
+  email = MOCK_AUTH_EMAIL,
+  password = MOCK_AUTH_PASS,
+) {
+  const { body } = await request(httpServer)
+    .post("/auth/login")
+    .send({ email, password })
+    .expect(HttpStatus.CREATED);
+
+  return body.data.accessToken;
+}

--- a/test/utils/helpers/users.helpers.ts
+++ b/test/utils/helpers/users.helpers.ts
@@ -7,17 +7,24 @@ import { ARGON2_OPTIONS } from "@/common/config/argon2.config";
 import { MOCK_AUTH_EMAIL, MOCK_AUTH_PASS } from "../../auth/auth.mock";
 import { UserFactory } from "../factories/users.factory";
 
-export const createUserInDb = async (dbService: EntityManager<IDatabaseDriver<Connection>>) => {
+export const createUserInDb = async (
+  dbService: EntityManager<IDatabaseDriver<Connection>>,
+  config?: {
+    email?: string;
+    password?: string;
+  },
+) => {
   const defaultConfig = {
     email: MOCK_AUTH_EMAIL,
     password: MOCK_AUTH_PASS,
   };
 
-  const password = defaultConfig.password;
+  const password = config?.password || defaultConfig.password;
   const hashedPassword = await argon2.hash(password, ARGON2_OPTIONS);
 
   const values = {
     ...defaultConfig,
+    ...config,
     password: hashedPassword,
   };
 


### PR DESCRIPTION
## Description of Change

- Added e2e test for GET `users/me` API
- Added access token helper function
- Modified createUserInDB method

## Associated Ticket Link(s)

- https://trello.com/c/A9RZrSvE

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings: N/A
