### PR TITLE
Add E2E spec test for PATCH `users/update-password` API

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -103,8 +103,9 @@ export class UsersService {
     const { email, newPassword, otp } = updatePasswordDto;
 
     const user = await this.usersRepository.findOneOrFail({ email });
+    const isVerified = await this.isOtpVerified(user, otp);
 
-    if (!this.isOtpVerified(user, otp)) {
+    if (!isVerified) {
       throw new UnauthorizedException("OTP isn't verified");
     }
     user.password = await this.hashPassword(newPassword);

--- a/test/utils/helpers/create-verify-user-in-db.helpers.ts
+++ b/test/utils/helpers/create-verify-user-in-db.helpers.ts
@@ -1,0 +1,24 @@
+import { Connection, EntityManager, IDatabaseDriver } from "@mikro-orm/core";
+
+import { faker } from "@faker-js/faker";
+import dayjs from "dayjs";
+
+import { User } from "@/common/entities/users.entity";
+import { VerifyUsers } from "@/common/entities/verify-users.entity";
+
+export const createVerifyUserInDb = async (
+  dbService: EntityManager<IDatabaseDriver<Connection>>,
+  user: User,
+  verify: boolean,
+) => {
+  const verifyUser = dbService.create(VerifyUsers, {
+    otp: faker.string.numeric({ length: 6 }),
+    expiresAt: dayjs().add(5, "minute").toDate(),
+    isChecked: verify,
+    user,
+  });
+
+  await dbService.persistAndFlush(verifyUser);
+
+  return verifyUser;
+};


### PR DESCRIPTION
## Description of Change

- Added helper method to create otp for verify user
- Added two tests for PATCH `users/update-password` API
- Fixed a bug that came from the test

## Associated Ticket Link(s)

- https://trello.com/c/ay0Gm4Eh
- https://trello.com/c/ECpIHWHe

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings: N/A
