### PR TITLE
Add E2E Spec Test for PATCH `classrooms/:classroomId` API

### DIFF
--- a/src/auth/guards/classrooms-ownership.guard.ts
+++ b/src/auth/guards/classrooms-ownership.guard.ts
@@ -19,7 +19,7 @@ export class ClassroomOwnershipGuard implements CanActivate {
 
     const userFromDb = await this.usersRepository.findOneOrFail({ id: user.id });
 
-    const classroom = await this.classroomsRepository.findOneOrFail({
+    const classroom = await this.classroomsRepository.findOne({
       id: classroomId,
       teacher: userFromDb.teacher.id,
     });


### PR DESCRIPTION
## Description of Change

- Added four tests for PATCH `classrooms/:classroomId` API
- Fix response exception type in classroom ownership guard

## Associated Ticket Link(s)

- https://trello.com/c/M9ODxUk1

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings: N/A
