### PR TITLE
Add E2E Spec Test for Removing Student from Classroom API

### DIFF
--- a/src/classrooms/classrooms.controller.ts
+++ b/src/classrooms/classrooms.controller.ts
@@ -59,18 +59,13 @@ export class ClassroomsController {
   }
 
   @Delete(":id/students")
-  @UseGuards(RolesGuard)
+  @UseGuards(RolesGuard, ClassroomOwnershipGuard)
   @Roles(EUserRole.TEACHER)
   removeStudentFromClassroom(
     @Param("id", ParseIntPipe) id: number,
-    @CurrentUser() user: ITokenizedUser,
     @Body() deleteEnrollDto: EnrollStudentDto,
   ) {
-    return this.classroomsService.removeStudentFromClassroom(
-      user.id,
-      id,
-      deleteEnrollDto.studentId,
-    );
+    return this.classroomsService.removeStudentFromClassroom(id, deleteEnrollDto.studentId);
   }
 
   @Get(":id/students")

--- a/src/classrooms/classrooms.service.ts
+++ b/src/classrooms/classrooms.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 
 import { EntityManager } from "@mikro-orm/postgresql";
 
@@ -87,17 +87,12 @@ export class ClassroomsService {
     return classroomStudent;
   }
 
-  async removeStudentFromClassroom(userId: number, classroomId: number, studentId: number) {
-    const user = await this.usersRepository.findOneOrFail({ id: userId });
+  async removeStudentFromClassroom(classroomId: number, studentId: number) {
     const classroom = await this.classroomsRepository.findOneOrFail({ id: classroomId });
 
-    if (user.teacher.id !== classroom.teacher.id) {
-      throw new UnauthorizedException("You are not the teacher of this classroom!");
-    }
-
     const classroomStudent = await this.classroomsStudentsRepository.findOneOrFail({
-      studentId,
-      classroomId,
+      studentId: studentId,
+      classroomId: classroom.id,
     });
 
     await this.em.removeAndFlush(classroomStudent);

--- a/test/classrooms/classrooms.e2e-spec.ts
+++ b/test/classrooms/classrooms.e2e-spec.ts
@@ -393,4 +393,69 @@ describe("ClassroomsController (e2e)", () => {
         .post(`/classrooms/${classroom.id}/students`)
         .expect(HttpStatus.UNAUTHORIZED));
   });
+
+  describe("DELETE /classrooms/:id/students", () => {
+    let teacherUser: User;
+    let anotherTeacherUser: User;
+    let studentUser: User;
+    let classroom: Classroom;
+    const testUserPassword = faker.internet.password();
+
+    beforeAll(async () => {
+      studentUser = await createSingleStudentUserInDb(dbService, {
+        email: faker.internet.email(),
+        password: testUserPassword,
+      });
+
+      teacherUser = await createSingleTeacherUserInDb(dbService, {
+        email: faker.internet.email(),
+        password: testUserPassword,
+      });
+
+      anotherTeacherUser = await createSingleTeacherUserInDb(dbService, {
+        email: faker.internet.email(),
+        password: testUserPassword,
+      });
+
+      const classrooms = await createClassroomInDb(dbService, teacherUser.teacher);
+      classroom = classrooms[0];
+
+      await enrollStudentInClassroomsInDb(dbService, classrooms, [studentUser.student]);
+    });
+
+    it("should return OK(200) after removing student from classroom by teacher", async () => {
+      const token = await getAccessToken(httpServer, teacherUser.email, testUserPassword);
+
+      await request(httpServer)
+        .delete(`/classrooms/${classroom.id}/students`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ studentId: studentUser.student.id })
+        .expect(HttpStatus.OK);
+    });
+
+    it("should return FORBIDDEN(403) for trying to remove as student", async () => {
+      const token = await getAccessToken(httpServer, studentUser.email, testUserPassword);
+
+      await request(httpServer)
+        .delete(`/classrooms/${classroom.id}/students`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ studentId: studentUser.student.id })
+        .expect(HttpStatus.FORBIDDEN);
+    });
+
+    it("should return FORBIDDEN(403) for trying to remove student in another teacher's classroom", async () => {
+      const token = await getAccessToken(httpServer, anotherTeacherUser.email, testUserPassword);
+
+      await request(httpServer)
+        .delete(`/classrooms/${classroom.id}/students`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ studentId: studentUser.student.id })
+        .expect(HttpStatus.FORBIDDEN);
+    });
+
+    it("returns UNAUTHORIZED(401) if user is not authenticated", () =>
+      request(httpServer)
+        .delete(`/classrooms/${classroom.id}/students`)
+        .expect(HttpStatus.UNAUTHORIZED));
+  });
 });


### PR DESCRIPTION
## Description of Change

- Added e2e spec test for DELETE `classrooms/:id/students` API
- Added classroom ownership guard in the API

## Associated Ticket Link(s)

- https://trello.com/c/BmcmtRX5

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings: N/A
